### PR TITLE
Updated golangci action to fix GH actions deprecation erorrs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
-        with:
-          version: v1.27
+        uses: golangci/golangci-lint-action@v2
 
   test:
     name: Test


### PR DESCRIPTION
Should fix

```
  Finding needed golangci-lint version...
  Setup go stable version spec 1
  Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.16.2/x64' successfully.
  Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  Error: Unable to process command '::add-path::/opt/hostedtoolcache/go/1.16.2/x64/bin' successfully.
  Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  Added go to the path
  Error: Unable to process command '::add-path::/home/runner/go/bin' successfully.
  Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```