### PR TITLE
Fix tests and json support for pg/v10 adapter

### DIFF
--- a/adapter/db.go
+++ b/adapter/db.go
@@ -16,7 +16,7 @@ var (
 type Row interface {
 	// Scan reads the values from the current row into dest values positionally.
 	// If no rows were found it returns ErrNoRows. If multiple rows are returned it
-	//ignores all but the first.
+	// ignores all but the first.
 	Scan(dest ...interface{}) error
 }
 

--- a/adapter/testing/gopgv10.go
+++ b/adapter/testing/gopgv10.go
@@ -40,5 +40,5 @@ func OpenTestPoolMaxConnsGoPGv10(t testing.TB, maxConnections int32) adapter.Con
 func OpenTestPoolGoPGv10(t testing.TB) adapter.ConnPool {
 	t.Helper()
 
-	return OpenTestPoolMaxConnsPGXv4(t, defaultPoolConns)
+	return OpenTestPoolMaxConnsGoPGv10(t, defaultPoolConns)
 }

--- a/adapter/testing/pgxv3.go
+++ b/adapter/testing/pgxv3.go
@@ -19,9 +19,7 @@ import (
 
 const defaultPoolConns = 5
 
-var (
-	migrations sync.Map
-)
+var migrations sync.Map
 
 func applyMigrations(schema string) *sync.Once {
 	once, _ := migrations.LoadOrStore(schema, &sync.Once{})
@@ -67,7 +65,7 @@ func testConnDSN(t testing.TB) string {
 	require.NotEmpty(t, testPgConnString, "TEST_POSTGRES env var is empty")
 
 	return testPgConnString
-	//return `postgres://test:test@localhost:54823/test?sslmode=disable`
+	// return `postgres://test:test@localhost:54823/test?sslmode=disable`
 }
 
 func testConnPGXv3Config(t testing.TB) pgx.ConnConfig {

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -81,7 +82,7 @@ func (c *Client) execEnqueue(ctx context.Context, j *Job, q adapter.Queryable) e
 (queue, priority, run_at, job_type, args, created_at, updated_at)
 VALUES
 ($1, $2, $3, $4, $5, $6, $6) RETURNING job_id
-`, j.Queue, j.Priority, j.RunAt, j.Type, j.Args, now).Scan(&j.ID)
+`, j.Queue, j.Priority, j.RunAt, j.Type, json.RawMessage(j.Args), now).Scan(&j.ID)
 
 	c.logger.Debug(
 		"Tried to enqueue a job",
@@ -123,7 +124,7 @@ LIMIT 1 FOR UPDATE SKIP LOCKED`, queue, now).Scan(
 		&j.Priority,
 		&j.RunAt,
 		&j.Type,
-		&j.Args,
+		(*json.RawMessage)(&j.Args),
 		&j.ErrorCount,
 	)
 	if err == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package gue
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -450,7 +451,7 @@ func findOneJob(t testing.TB, q adapter.Queryable) *Job {
 		&j.RunAt,
 		&j.ID,
 		&j.Type,
-		&j.Args,
+		(*json.RawMessage)(&j.Args),
 		&j.ErrorCount,
 		&j.LastError,
 		&j.Queue,

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -87,11 +87,6 @@ func TestEnqueueWithRunAt(t *testing.T) {
 		testEnqueueWithRunAt(t, adapterTesting.OpenTestPoolPGXv4(t))
 	})
 	t.Run("lib/pq", func(t *testing.T) {
-		// FIXME: looks like lib/pq does not default to UTC timezone and generally
-		// handles timezones poorly. The test still passes sometimes though so skipping
-		// it as flaky for now.
-		t.Skip("skipping flaky lib/pq timezone test")
-
 		testEnqueueWithRunAt(t, adapterTesting.OpenTestPoolLibPQ(t))
 	})
 	t.Run("go-pg/v10", func(t *testing.T) {
@@ -111,8 +106,7 @@ func testEnqueueWithRunAt(t *testing.T, connPool adapter.ConnPool) {
 	require.NotNil(t, j)
 
 	// truncate to the microsecond as postgres driver does
-	want = want.Truncate(time.Microsecond)
-	assert.True(t, want.Equal(j.RunAt))
+	assert.True(t, want.Sub(j.RunAt) <= time.Microsecond)
 }
 
 func TestEnqueueWithArgs(t *testing.T) {

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -106,7 +106,7 @@ func testEnqueueWithRunAt(t *testing.T, connPool adapter.ConnPool) {
 	require.NotNil(t, j)
 
 	// truncate to the microsecond as postgres driver does
-	assert.True(t, want.Sub(j.RunAt) <= time.Microsecond)
+	assert.WithinDuration(t, want, j.RunAt, time.Microsecond)
 }
 
 func TestEnqueueWithArgs(t *testing.T) {

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -141,7 +141,7 @@ func testEnqueueWithArgs(t *testing.T, connPool adapter.ConnPool) {
 	j := findOneJob(t, connPool)
 	require.NotNil(t, j)
 
-	assert.Equal(t, want, j.Args)
+	assert.JSONEq(t, string(want), string(j.Args))
 }
 
 func TestEnqueueWithQueue(t *testing.T) {


### PR DESCRIPTION
Oops, I’ve messed up a bit in the [previous PR](https://github.com/vgarvardt/gue/pull/34).

- `OpenTestPoolGoPGv10` should call `OpenTestPoolMaxConnsGoPGv10` instead of `OpenTestPoolMaxConnsPGXv4` 😅
- go-pg expects parameters for json columns to have `json.RawMessage` type (alternatively, we can use bytea column)

Also fixes failing lib/pq tests by using `Sub ≤ time.Millisecond` instead of `Truncate`.
