### PR TITLE
Allow Client To Pass Context In WorkFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ type printNameArgs struct {
 }
 
 func main() {
-    printName := func(j *gue.Job) error {
+    printName := func(ctx context.Context, j *gue.Job) error {
         var args printNameArgs
         if err := json.Unmarshal(j.Args, &args); err != nil {
             return err

--- a/worker.go
+++ b/worker.go
@@ -20,7 +20,7 @@ const (
 
 // WorkFunc is a function that performs a Job. If an error is returned, the job
 // is re-enqueued with exponential backoff.
-type WorkFunc func(j *Job) error
+type WorkFunc func(ctx context.Context, j *Job) error
 
 // WorkMap is a map of Job names to WorkFuncs that are used to perform Jobs of a
 // given type.
@@ -179,7 +179,7 @@ func (w *Worker) WorkOne(ctx context.Context) (didWork bool) {
 		return
 	}
 
-	if err = wf(j); err != nil {
+	if err = wf(ctx, j); err != nil {
 		if jErr := j.Error(ctx, err.Error()); jErr != nil {
 			ll.Error("Got an error on setting an error to an errored job", adapter.Err(jErr), adapter.F("job-error", err))
 		}

--- a/worker_option_test.go
+++ b/worker_option_test.go
@@ -1,6 +1,7 @@
 package gue
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func (m *mockLogger) With(fields ...adapter.Field) adapter.Logger {
 
 func TestWithWorkerPollInterval(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -48,7 +49,7 @@ func TestWithWorkerPollInterval(t *testing.T) {
 
 func TestWithWorkerQueue(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -63,7 +64,7 @@ func TestWithWorkerQueue(t *testing.T) {
 
 func TestWithWorkerID(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -78,7 +79,7 @@ func TestWithWorkerID(t *testing.T) {
 
 func TestWithWorkerLogger(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -101,7 +102,7 @@ func TestWithWorkerLogger(t *testing.T) {
 
 func TestWithPoolPollInterval(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -116,7 +117,7 @@ func TestWithPoolPollInterval(t *testing.T) {
 
 func TestWithPoolQueue(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -131,7 +132,7 @@ func TestWithPoolQueue(t *testing.T) {
 
 func TestWithPoolID(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}
@@ -146,7 +147,7 @@ func TestWithPoolID(t *testing.T) {
 
 func TestWithPoolLogger(t *testing.T) {
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			return nil
 		},
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -36,7 +36,7 @@ func testWorkerWorkOne(t *testing.T, connPool adapter.ConnPool) {
 
 	success := false
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			success = true
 			return nil
 		},
@@ -262,7 +262,7 @@ func benchmarkWorker(b *testing.B, connPool adapter.ConnPool) {
 	}
 }
 
-func nilWorker(j *Job) error {
+func nilWorker(ctx context.Context, j *Job) error {
 	return nil
 }
 
@@ -287,7 +287,7 @@ func testWorkerWorkReturnsError(t *testing.T, connPool adapter.ConnPool) {
 
 	called := 0
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			called++
 			return errors.New("the error msg")
 		},
@@ -333,7 +333,7 @@ func testWorkerWorkRescuesPanic(t *testing.T, connPool adapter.ConnPool) {
 
 	called := 0
 	wm := WorkMap{
-		"MyJob": func(j *Job) error {
+		"MyJob": func(ctx context.Context, j *Job) error {
 			called++
 			panic("the panic msg")
 		},


### PR DESCRIPTION
Proposal to let clients pass their context to WorkFunc, which can then be used to extract metadata in the WorkFunc implementation. 
One example is that this would allow to chain middlewares, where the context is used to populate metadata and then is passed through the argument of the function:


```
func CtxMiddleware(handler gue.WorkFunc) gue.WorkFunc {
           return func(ctx context.Context, job *gue.Job) (err error) {
		
		// put some metadata info to context
		
                  return handler(ctx, job)
	}
}
```