### PR TITLE
Add LockJobByID function

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -160,6 +160,117 @@ func testLockJobCustomQueue(t *testing.T, connPool adapter.ConnPool) {
 	require.NoError(t, err)
 }
 
+func TestLockJobByID(t *testing.T) {
+	t.Run("pgx/v3", func(t *testing.T) {
+		testLockJobByID(t, adapterTesting.OpenTestPoolPGXv3(t))
+	})
+	t.Run("pgx/v4", func(t *testing.T) {
+		testLockJobByID(t, adapterTesting.OpenTestPoolPGXv4(t))
+	})
+	t.Run("lib/pq", func(t *testing.T) {
+		testLockJobByID(t, adapterTesting.OpenTestPoolLibPQ(t))
+	})
+	t.Run("go-pg/v10", func(t *testing.T) {
+		testLockJobByID(t, adapterTesting.OpenTestPoolGoPGv10(t))
+	})
+}
+
+func testLockJobByID(t *testing.T, connPool adapter.ConnPool) {
+	c := NewClient(connPool)
+	ctx := context.Background()
+
+	newJob := &Job{
+		Type: "MyJob",
+	}
+	err := c.Enqueue(ctx, newJob)
+	require.NoError(t, err)
+	require.Greater(t, newJob.ID, int64(0))
+
+	j, err := c.LockJobByID(ctx, newJob.ID)
+	require.NoError(t, err)
+
+	require.NotNil(t, j.tx)
+	require.NotNil(t, j.pool)
+	defer func() {
+		err := j.Done(ctx)
+		assert.NoError(t, err)
+	}()
+
+	// check values of returned Job
+	assert.Equal(t, newJob.ID, j.ID)
+	assert.Equal(t, defaultQueueName, j.Queue)
+	assert.Equal(t, int16(0), j.Priority)
+	assert.False(t, j.RunAt.IsZero())
+	assert.Equal(t, newJob.Type, j.Type)
+	assert.Equal(t, []byte(`[]`), j.Args)
+	assert.Equal(t, int32(0), j.ErrorCount)
+	assert.NotEqual(t, pgtype.Present, j.LastError.Status)
+}
+
+func TestLockJobByIDAlreadyLocked(t *testing.T) {
+	t.Run("pgx/v3", func(t *testing.T) {
+		testLockJobByIDAlreadyLocked(t, adapterTesting.OpenTestPoolPGXv3(t))
+	})
+	t.Run("pgx/v4", func(t *testing.T) {
+		testLockJobByIDAlreadyLocked(t, adapterTesting.OpenTestPoolPGXv4(t))
+	})
+	t.Run("lib/pq", func(t *testing.T) {
+		testLockJobByIDAlreadyLocked(t, adapterTesting.OpenTestPoolLibPQ(t))
+	})
+	t.Run("go-pg/v10", func(t *testing.T) {
+		testLockJobByIDAlreadyLocked(t, adapterTesting.OpenTestPoolGoPGv10(t))
+	})
+}
+
+func testLockJobByIDAlreadyLocked(t *testing.T, connPool adapter.ConnPool) {
+	c := NewClient(connPool)
+	ctx := context.Background()
+
+	newJob := &Job{
+		Type: "MyJob",
+	}
+
+	err := c.Enqueue(ctx, newJob)
+	require.NoError(t, err)
+
+	j, err := c.LockJobByID(ctx, newJob.ID)
+	require.NoError(t, err)
+
+	defer func() {
+		err := j.Done(ctx)
+		assert.NoError(t, err)
+	}()
+	require.NotNil(t, j)
+
+	j2, err := c.LockJobByID(ctx, newJob.ID)
+	require.Error(t, err)
+	require.Nil(t, j2)
+}
+
+func TestLockJobByIDNoJob(t *testing.T) {
+	t.Run("pgx/v3", func(t *testing.T) {
+		testLockJobByIDNoJob(t, adapterTesting.OpenTestPoolPGXv3(t))
+	})
+	t.Run("pgx/v4", func(t *testing.T) {
+		testLockJobByIDNoJob(t, adapterTesting.OpenTestPoolPGXv4(t))
+	})
+	t.Run("lib/pq", func(t *testing.T) {
+		testLockJobByIDNoJob(t, adapterTesting.OpenTestPoolLibPQ(t))
+	})
+	t.Run("go-pg/v10", func(t *testing.T) {
+		testLockJobByIDNoJob(t, adapterTesting.OpenTestPoolGoPGv10(t))
+	})
+}
+
+func testLockJobByIDNoJob(t *testing.T, connPool adapter.ConnPool) {
+	c := NewClient(connPool)
+	ctx := context.Background()
+
+	j, err := c.LockJobByID(ctx, 0)
+	require.Error(t, err)
+	require.Nil(t, j)
+}
+
 func TestJobTx(t *testing.T) {
 	t.Run("pgx/v3", func(t *testing.T) {
 		testJobTx(t, adapterTesting.OpenTestPoolPGXv3(t))


### PR DESCRIPTION
Proposal to add `LockJobById` function. At the moment, clients can not remove a specific job from the queue because there is no way to retrieve a specific job. With this new function, clients can now call `job.Delete()` and `job.Done()` to remove a retrieved job from the queue. 