### PR TITLE
Job done hooks are called after the transaction is closed for the done job

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -229,13 +229,13 @@ func (w *Worker) WorkOne(ctx context.Context) (didWork bool) {
 	if err = wf(ctx, j); err != nil {
 		w.mWorked.Add(ctx, 1, attrJobType.String(j.Type), attrSuccess.Bool(false))
 
+		for _, hook := range w.hooksJobDone {
+			hook(ctx, j, err)
+		}
+
 		if jErr := j.Error(ctx, err.Error()); jErr != nil {
 			span.RecordError(fmt.Errorf("failed to mark job as error: %w", err))
 			ll.Error("Got an error on setting an error to an errored job", adapter.Err(jErr), adapter.F("job-error", err))
-		}
-
-		for _, hook := range w.hooksJobDone {
-			hook(ctx, j, err)
 		}
 
 		return

--- a/worker_option.go
+++ b/worker_option.go
@@ -76,7 +76,9 @@ func WithWorkerHooksUnknownJobType(hooks ...HookFunc) WorkerOption {
 	}
 }
 
-// WithWorkerHooksJobDone sets hooks that are called when worker finished working the job.
+// WithWorkerHooksJobDone sets hooks that are called when worker finished working the job,
+// right before the successfully executed job will be removed or errored job handler will be called to decide
+// if the Job will be re-queued or discarded.
 // Error field is set for the cases when the job was worked with an error.
 func WithWorkerHooksJobDone(hooks ...HookFunc) WorkerOption {
 	return func(w *Worker) {


### PR DESCRIPTION
Addresses https://github.com/vgarvardt/gue/issues/65

`hooksJobDone` are called before the job is marked as `Done`, so for error job the behaviour is the same as for successful - first call the hooks and only after mark it as Done with the done/err resolution.