### PR TITLE
Keep finished jobs in the database for history, but skip it while processing queue

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS gue_jobs
   run_at      TIMESTAMPTZ NOT NULL,
   job_type    TEXT        NOT NULL,
   args        BYTEA       NOT NULL,
+  skip_delete SMALLINT    NOT NULL,
+  status      TEXT        NOT NULL,
   error_count INTEGER     NOT NULL DEFAULT 0,
   last_error  TEXT,
   queue       TEXT        NOT NULL,

--- a/worker.go
+++ b/worker.go
@@ -265,7 +265,7 @@ func (w *Worker) WorkOne(ctx context.Context) (didWork bool) {
 		hook(ctx, j, nil)
 	}
 
-	err = j.Delete(ctx)
+	err = j.Finish(ctx, JobStatusSuccess)
 	if err != nil {
 		span.RecordError(fmt.Errorf("failed to delete finished job: %w", err))
 		ll.Error("Got an error on deleting a job", adapter.Err(err))


### PR DESCRIPTION
It's a useful feature to keep finished jobs in the database. Especially for production environment where this feature can help to discover bug cases in service logic by keeping failed and successful jobs. Clients can use it as well as logs.
Gue will ensure to keep finished jobs in the database using the job's 'SkipDelete' property. But client should handle and monitor the memory size that these jobs take up and reduce the size when it's necessary. 