### PR TITLE
ci: updated versions for setup-go and setup-task actions

### DIFF
--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -12,11 +12,11 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
 
     - name: Install Task
-      uses: arduino/setup-task@v1
+      uses: arduino/setup-task@v2
       with:
         repo-token: ${{ inputs.token }}


### PR DESCRIPTION
logic is not actually used and will be adjusted in https://github.com/Qubit-9/storage-cloud/pull/4027 as we have only one node and selector always uses early return