### PR TITLE
Added support for job type filtering on workers and pool workers

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -4,9 +4,7 @@ import "context"
 
 type ctxKey struct{}
 
-var (
-	workerIdxKey = ctxKey{}
-)
+var workerIdxKey = ctxKey{}
 
 const (
 	// WorkerIdxUnknown is returned when worker index in the pool is not set for some reason.

--- a/job_query.go
+++ b/job_query.go
@@ -1,0 +1,41 @@
+package gue
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	sqlSelectFrom           = "SELECT job_id, queue, priority, run_at, job_type, args, error_count, last_error, created_at FROM gue_jobs"
+	sqlLimitLock            = "LIMIT 1 FOR UPDATE SKIP LOCKED"
+	sqlOrderByPriority      = "ORDER BY priority ASC"
+	sqlOrderByRunAtPriority = "ORDER BY run_at, priority ASC"
+)
+
+func newLockJobQuery(queue string, jobTypes []string) (string, []any) {
+	whereClause, args := buildWhereClause(queue, jobTypes)
+	sql := fmt.Sprintf(`%s %s %s %s`, sqlSelectFrom, whereClause, sqlOrderByPriority, sqlLimitLock)
+	return sql, args
+}
+
+func newLockByIDQuery(id ulid.ULID) (string, []any) {
+	return fmt.Sprintf(`%s WHERE job_id = $1 %s`, sqlSelectFrom, sqlLimitLock), []any{id}
+}
+
+func newLockNextScheduledJobQuery(queue string, jobTypes []string) (string, []any) {
+	whereClause, args := buildWhereClause(queue, jobTypes)
+	sql := fmt.Sprintf(`%s %s %s %s`, sqlSelectFrom, whereClause, sqlOrderByRunAtPriority, sqlLimitLock)
+	return sql, args
+}
+
+func buildWhereClause(queue string, jobTypes []string) (string, []any) {
+	whereClause := `WHERE queue = $1 AND run_at <= $2`
+	args := []interface{}{queue, time.Now().UTC()}
+	if len(jobTypes) > 0 {
+		whereClause += " AND job_type = ANY ($3::TEXT[])"
+		args = append(args, jobTypes)
+	}
+	return whereClause, args
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -12,4 +12,4 @@ CREATE TABLE IF NOT EXISTS gue_jobs
   updated_at  TIMESTAMPTZ NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_gue_jobs_selector ON gue_jobs (queue, run_at, priority);
+CREATE INDEX IF NOT EXISTS idx_gue_jobs_selector ON gue_jobs (queue, job_type, run_at, priority);

--- a/worker_option.go
+++ b/worker_option.go
@@ -31,6 +31,13 @@ func WithWorkerQueue(queue string) WorkerOption {
 	}
 }
 
+// WithWorkerJobTypes limits/filters the job types this worker will fetch from the DB.
+func WithWorkerJobTypes(jobTypes []string) WorkerOption {
+	return func(w *Worker) {
+		w.jobTypes = jobTypes
+	}
+}
+
 // WithWorkerID sets worker ID for easier identification in logs
 func WithWorkerID(id string) WorkerOption {
 	return func(w *Worker) {
@@ -168,6 +175,13 @@ func WithPoolPollInterval(d time.Duration) WorkerPoolOption {
 func WithPoolQueue(queue string) WorkerPoolOption {
 	return func(w *WorkerPool) {
 		w.queue = queue
+	}
+}
+
+// WithPoolJobTypes limits/filters the job types this worker will fetch from the DB.
+func WithPoolJobTypes(jobTypes ...string) WorkerPoolOption {
+	return func(w *WorkerPool) {
+		w.jobTypes = jobTypes
 	}
 }
 


### PR DESCRIPTION
I have added an option to Workers and PoolWorkers so they can filter/poll only jobs of specific job types.
This way you can have several pools or services polling from the same queue, and not having to implement all job types or define a handler for unknown types. (specially if a new type is added later on)

Also, with this implementation workers will not lock unsupported jobs, blocking other workers that can process those jobs/rows.

There is more info in this issue: https://github.com/vgarvardt/gue/issues/291

I've created some functions to generate the final queries using constants, as the queries are not static anymore.

PS: If this gets merged, README/examples/documentation might need to be updated. Although the signatures are not changed and is fully compatible with the previous version.
