### PR TITLE
chore: bump min required golang version to 1.22

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Golang

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21", "1.22", "stable"]
+        go-version: ["1.22", "1.23", "1.24", "stable"]
     timeout-minutes: 10
     steps:
       - name: Check out code

--- a/_example/outbox-worker-kafka/go.mod
+++ b/_example/outbox-worker-kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/vgarvardt/gue/v5/example/outbox-worker-kafka
 
-go 1.21
+go 1.22
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vgarvardt/gue/v5
 
-go 1.21
+go 1.22
 
 require (
 	github.com/jackc/pgconn v1.14.3


### PR DESCRIPTION
1.21 reached EOL long time ago