### PR TITLE
chore: bump min required golang version to 1.23

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -21,9 +21,6 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default
     min-complexity: 15
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   revive:
     rules:
       - name: exported

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps
         with:
-          go-version: "1.22"
+          go-version: "1.23"
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           args: >
             --config=./.github/linters/.golangci.yml
+            --timeout=5m
 
   codespell:
     name: Check spelling

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps
         with:
-          go-version: "1.22"
+          go-version: "1.23"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Golang

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22", "1.23", "1.24", "stable"]
+        go-version: ["1.23", "1.24", "stable"]
     timeout-minutes: 10
     steps:
       - name: Check out code
@@ -37,7 +37,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
           fail_ci_if_error: false
 
   summary:

--- a/_example/outbox-worker-kafka/go.mod
+++ b/_example/outbox-worker-kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/vgarvardt/gue/v5/example/outbox-worker-kafka
 
-go 1.22
+go 1.23
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vgarvardt/gue/v5
 
-go 1.22
+go 1.23
 
 require (
 	github.com/jackc/pgconn v1.14.3


### PR DESCRIPTION
let's support only two latest golang versions